### PR TITLE
[iOS] Make layouts work with smaller sizes

### DIFF
--- a/iosApp/iosApp/Screens/Cards/CardsView.swift
+++ b/iosApp/iosApp/Screens/Cards/CardsView.swift
@@ -57,7 +57,6 @@ struct CardsView<ViewModel: GameModelProtocol>: View {
             }
             Spacer()
         }
-        .ignoresSafeArea()
     }
 }
 

--- a/iosApp/iosApp/Screens/ContainerView.swift
+++ b/iosApp/iosApp/Screens/ContainerView.swift
@@ -33,12 +33,10 @@ struct ContainerView<Content: View>: View {
             VStack {
                 HeaderView(size: headerSize)
                     .fixedSize(horizontal: false, vertical: true)
-                    .ignoresSafeArea(.all)
                 content
                 Spacer()
                     .frame(height: .extraLarge)
             }
-            .ignoresSafeArea(.all, edges: .top)
         }
         .navigationBarBackButtonHidden(true)
     }

--- a/iosApp/iosApp/Screens/CurrentRound/CurrentRoundView.swift
+++ b/iosApp/iosApp/Screens/CurrentRound/CurrentRoundView.swift
@@ -47,27 +47,25 @@ struct CurrentRoundView<ViewModel: GameModelProtocol>: View {
                                 .font(hasLoaded ? .titleSemiBold : .largeTitleSemiBold)
                             Spacer()
                             if hasLoaded {
-                                if hasShiftedTitle {
-                                    ZStack(alignment: .bottom) {
+                                ZStack(alignment: .bottom) {
+                                    VStack {
+                                        QuestionCardView(question: round.questionCard.question)
+                                            .font(.inputPrimary)
+                                            .shadow(radius: 8.0, y: 4.0)
+                                        Spacer()
+                                    }
+                                    if let confirmedCard {
                                         VStack {
-                                            QuestionCardView(question: round.questionCard.question)
-                                                .font(.inputPrimary)
                                             Spacer()
-                                        }
-                                        if let confirmedCard {
-                                            VStack {
-                                                Spacer()
-                                                AnswerCardView(answer: confirmedCard.text)
-                                                    .font(.cardSmall)
-                                                    .frame(width: 124, height: 168)
-                                                    .rotationEffect(.degrees(-5))
-                                                    .offset(x: -62)
-                                            }
+                                            AnswerCardView(answer: confirmedCard.text)
+                                                .font(.cardSmall)
+                                                .frame(width: 124, height: 168)
+                                                .rotationEffect(.degrees(-5))
+                                                .offset(x: -62)
                                         }
                                     }
-                                } else {
-                                    Spacer(minLength: 200)
                                 }
+                                .opacity(hasShiftedTitle ? 1 : 0)
                                 Spacer()
                                 Spacer()
                                 Text("Оберіть відповідь:")
@@ -76,9 +74,9 @@ struct CurrentRoundView<ViewModel: GameModelProtocol>: View {
                                     selectedCard: $viewModel.selectedCard,
                                     answers: cardsInHand
                                 )
-                                .padding(.bottom, .large)
                             }
                         }
+                        .padding(.bottom, .extraLarge)
                     }
                 }
                 if hasLoaded {

--- a/iosApp/iosApp/Screens/CurrentRound/FullScreenHandView.swift
+++ b/iosApp/iosApp/Screens/CurrentRound/FullScreenHandView.swift
@@ -36,17 +36,14 @@ struct FullScreenHandView: View {
                 .padding(.top, HeaderSize.small.headerBackgroundBottomPadding + 12)
             }
             .offset(y: HeaderSize.small.height - HeaderSize.small.headerBackgroundBottomPadding)
-
-            .ignoresSafeArea(.all)
+            .ignoresSafeArea(.all, edges: .bottom)
             Spacer()
         }
         VStack {
             HeaderView(size: .small)
                 .fixedSize(horizontal: false, vertical: true)
-                .ignoresSafeArea(.all)
             Spacer()
         }
-        .ignoresSafeArea(.all)
         .navigationBarBackButtonHidden(true)
     }
 }

--- a/iosApp/iosApp/Screens/MainMenu/MainMenuView.swift
+++ b/iosApp/iosApp/Screens/MainMenu/MainMenuView.swift
@@ -26,12 +26,15 @@ struct MainMenuView: View {
             }
             VStack {
                 headerView
-                Spacer(minLength: 64)
-                if isLoaded {
-                    buttonStack
-                        .opacity(isShowingButtons ? 1 : 0)
+                VStack {
+                    Spacer()
+                        .frame(height: 64)
+                    if isLoaded {
+                        buttonStack
+                            .opacity(isShowingButtons ? 1 : 0)
+                        Spacer()
+                    }
                 }
-                Spacer(minLength: 262)
                 footerView
             }
             .ignoresSafeArea()

--- a/iosApp/iosApp/Views/Cards/CardHandPicker.swift
+++ b/iosApp/iosApp/Views/Cards/CardHandPicker.swift
@@ -25,7 +25,6 @@ struct CardHandPicker: View {
                     ForEach(Array(answers.enumerated()), id: \.offset) { (offset, answerItem) in
                         AnswerCardView(answer: answerItem.text)
                             .font(.inputPrimary)
-                            .frame(width: 180, height: 240)
                             .scaleEffect(getScale(offset), anchor: .bottom)
                             .rotationEffect(.degrees(getRotation(offset)))
                             .offset(x: CGFloat(offset) * 90)

--- a/iosApp/iosApp/Views/Cards/QuestionCardView.swift
+++ b/iosApp/iosApp/Views/Cards/QuestionCardView.swift
@@ -26,7 +26,6 @@ struct QuestionCardView: View {
         .background(Color.mainBlack)
         .aspectRatio(124 / 168, contentMode: .fit)
         .cornerRadius(8.0)
-//        .shadow(radius: 8.0, y: 4.0)
     }
 }
 

--- a/iosApp/iosApp/Views/Header/HeaderSize.swift
+++ b/iosApp/iosApp/Views/Header/HeaderSize.swift
@@ -14,8 +14,8 @@ enum HeaderSize {
 
     var height: CGFloat {
         switch self {
-        case .small: return 146
-        case .medium: return 210
+        case .small: return 100
+        case .medium: return 180
         }
     }
 

--- a/iosApp/iosApp/Views/Header/HeaderView.swift
+++ b/iosApp/iosApp/Views/Header/HeaderView.swift
@@ -16,6 +16,7 @@ struct HeaderView: View {
     var body: some View {
         ZStack {
             Image.bgTexture
+                .ignoresSafeArea()
                 .padding(.bottom, size.headerBackgroundBottomPadding)
             VStack {
                 Spacer()
@@ -25,7 +26,6 @@ struct HeaderView: View {
                     .frame(width: size.logoWidth)
             }
         }
-        .ignoresSafeArea()
         .frame(height: size.height)
     }
 }


### PR DESCRIPTION
## In this PR
- Fix proportions of question and answer cards in current round view
- Make animation smoother when showing cards in current round view
- Use safe area to fix header height for different device sizes
- Get rid of hardcoded height in main menu, make it work for small sizes as well  

related to #17  

**TODO:** Choose and apply a solution for proper font sizing on different screens when the text is too large
## Recordings
#### Main menu animation (iPhone SE):
[<img src="https://user-images.githubusercontent.com/105276702/222714290-b5b1d964-79fe-4633-8343-bc116b622587.mov" width=40%>](https://user-images.githubusercontent.com/105276702/222714290-b5b1d964-79fe-4633-8343-bc116b622587.mov)  

#### Current round screen (iPhone SE):
[<img src="https://user-images.githubusercontent.com/105276702/222714570-e2c1255a-5cf7-409f-a6a7-2ceba3deaaba.mov" width=40%>](https://user-images.githubusercontent.com/105276702/222714570-e2c1255a-5cf7-409f-a6a7-2ceba3deaaba.mov)


