### PR TITLE
[CI] Prevent CI jobs from running on draft PRs

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   android_build:
     runs-on: ubuntu-latest
+    if: '! github.event.pull_request.draft'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   android_build:
     runs-on: ubuntu-latest
-    if: '! github.event.pull_request.draft'
+    if: github.event.pull_request.draft == false
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -11,6 +11,11 @@ on:
   pull_request:
       branches:
           - develop
+      types:
+          - opened
+          - reopened
+          - synchronize
+          - ready_for_review
 
 jobs:
   android_build:

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   ios_tests:
     runs-on: macos-latest
-    if: '! github.event.pull_request.draft'
+    if: github.event.pull_request.draft == false
 
     steps:
     - uses: devbotsxyz/xcode-select@v1

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   ios_tests:
     runs-on: macos-latest
+    if: '! github.event.pull_request.draft'
 
     steps:
     - uses: devbotsxyz/xcode-select@v1

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -11,6 +11,11 @@ on:
   pull_request:
       branches:
           - develop
+      types:
+          - opened
+          - reopened
+          - synchronize
+          - ready_for_review
 
 jobs:
   ios_tests:

--- a/iosApp/iosApp/Views/InputField.swift
+++ b/iosApp/iosApp/Views/InputField.swift
@@ -26,8 +26,8 @@ struct InputField: View {
         TextField(prompt, text: $text)
             .focused(isFocused)
             .font(.inputPrimary)
-            .padding(.vertical, .medium)
             .padding(.horizontal, .medium)
+            .padding(.vertical, .medium)
             .background(
                 RoundedRectangle(cornerRadius: 4)
                     .strokeBorder(lineWidth: 1)

--- a/iosApp/iosApp/Views/InputField.swift
+++ b/iosApp/iosApp/Views/InputField.swift
@@ -13,21 +13,17 @@ struct InputField: View {
     @Binding private var text: String
     private let prompt: String
     var isFocused: FocusState<Bool>.Binding
-    let onEditingChanged: (Bool) -> Void
-    let onCommit: () -> Void
 
-    init(_ prompt: String, text: Binding<String>, isFocused: FocusState<Bool>.Binding, onEditingChanged: @escaping (Bool) -> Void = { _ in }, onCommit: @escaping () -> Void = {}) {
+    init(_ prompt: String, text: Binding<String>, isFocused: FocusState<Bool>.Binding) {
         self.prompt = prompt
         self._text = text
         self.isFocused = isFocused
-        self.onEditingChanged = onEditingChanged
-        self.onCommit = onCommit
     }
 
     // MARK: - Body
 
     var body: some View {
-        TextField(prompt, text: $text, onEditingChanged: onEditingChanged, onCommit: onCommit)
+        TextField(prompt, text: $text)
             .focused(isFocused)
             .font(.inputPrimary)
             .padding(.vertical, .medium)
@@ -48,7 +44,7 @@ struct InputField_Previews: PreviewProvider {
     @FocusState private static var isFocused: Bool
 
     static var previews: some View {
-        InputField("Enter text", text: $text,  isFocused: $isFocused, onEditingChanged: { _ in })
+        InputField("Enter text", text: $text,  isFocused: $isFocused)
             .previewLayout(.sizeThatFits)
     }
 }


### PR DESCRIPTION
## In this PR
- Added `if` check to github workflows to prevent them from running on draft PRs
- While testing it, removed some redundant code from iOS `InputField`