### PR TITLE
[iOS] Connect voting screen

### DIFF
--- a/iosApp/iosApp/Presentation/EffectProcessors/GameEffectProcessor.swift
+++ b/iosApp/iosApp/Presentation/EffectProcessors/GameEffectProcessor.swift
@@ -31,7 +31,7 @@ final class GameEffectProcessor {
             // TODO: Support if there is a good-looking solution
             break
         case is GameContractEffect.NavigationVoting:
-            alertState.presentedAlertType = .noFeature
+            gameNavState = .voting
         case is GameContractEffect.NavigationRoundLeaderBoard:
             gameNavState = .leaderBoard
         default:

--- a/iosApp/iosApp/Screens/Cards/AnswerCardEntity.swift
+++ b/iosApp/iosApp/Screens/Cards/AnswerCardEntity.swift
@@ -11,6 +11,7 @@ import Foundation
 struct AnswerCardEntity: Identifiable, Hashable {
     let id: String
     let text: String
+    var isUsed: Bool = false
 }
 
 extension AnswerCardEntity {

--- a/iosApp/iosApp/Screens/Cards/GameModel.swift
+++ b/iosApp/iosApp/Screens/Cards/GameModel.swift
@@ -54,9 +54,9 @@ class GameModel: GameModelProtocol {
         // FIXME: This is bad, should be done inside shared KMM GameViewModel
         // Should be something like vm.vote(cardId: ..., score: ...)
         guard let round else { return }
-        guard index >= 0 && index < round.playerCards.count else { return }
+        guard index >= 0 && index < round.answers.count else { return }
 
-        let answerEntity = round.playerCards[index]
+        let answerEntity = round.answers[index]
         let playerAnswers = answerEntity.playerAnswers.map {
             AnswerCard(id: $0.id, answer: $0.text, isUsed: $0.isUsed)
         }
@@ -116,7 +116,7 @@ class GameModel: GameModelProtocol {
                     question: round.masterCard.question,
                     gaps: round.masterCard.gaps.compactMap { NSNumber(nonretainedObject: $0) }
                 ),
-                playerAnswers: round.answers.compactMap { playerCards in
+                answers: round.answers.compactMap { playerCards in
                     RoundPlayerAnswerEntity(
                         player: playerEntities.first(where: { $0.id == playerCards.playerID }) ?? PlayerEntity.mock[0],
                         playerAnswers: playerCards.playerAnswers.map({

--- a/iosApp/iosApp/Screens/Cards/GameModel.swift
+++ b/iosApp/iosApp/Screens/Cards/GameModel.swift
@@ -49,6 +49,10 @@ class GameModel: GameModelProtocol {
         vm.saveAnswers(answerCardIds: answerCardIds)
     }
 
+    func saveScore(answerCardIds: [String]) {
+        vm.saveScores(answerCardWithVotes: [])
+    }
+
     func startNewRound() {
         vm.startNewRound()
     }

--- a/iosApp/iosApp/Screens/Cards/GameRoundEntity.swift
+++ b/iosApp/iosApp/Screens/Cards/GameRoundEntity.swift
@@ -17,14 +17,14 @@ struct GameRoundEntity {
     let id: String
     let number: Int
     let questionCard: QuestionCardEntity
-    let playerAnswers: [RoundPlayerAnswerEntity]
+    let answers: [RoundPlayerAnswerEntity]
     let state: State
 
     static let mock: GameRoundEntity = GameRoundEntity(
         id: "123",
         number: 1,
         questionCard: QuestionCardEntity(id: "1", text: "What happened here?", question: "What happened there?", gaps: [0, 1, 2]),
-        playerAnswers: RoundPlayerAnswerEntity.mock,
+        answers: RoundPlayerAnswerEntity.mock,
         state: .VOTING
     )
 }

--- a/iosApp/iosApp/Screens/Cards/RoundPlayerAnswerEntity.swift
+++ b/iosApp/iosApp/Screens/Cards/RoundPlayerAnswerEntity.swift
@@ -11,10 +11,19 @@ import Foundation
 struct RoundPlayerAnswerEntity: Identifiable {
     var id: UUID = UUID()
     let player: PlayerEntity
-    let playerAnswers: [String]
+    let playerAnswers: [AnswerCardEntity]
     let score: Int
 
     static let mock: [RoundPlayerAnswerEntity] = {
-        return PlayerEntity.mock.map { .init(player: $0, playerAnswers: ["Answer 0.", "Very really unjustifiably long answer for this question that was much longer in my head then I initially suspected."], score: 42) }
+        return PlayerEntity.mock.map {
+            .init(
+                player: $0,
+                playerAnswers: [
+                    AnswerCardEntity(id: UUID().uuidString, text: "Answer 0."),
+                    AnswerCardEntity(id: UUID().uuidString, text: "Very really unjustifiably long answer for this question that was much longer in my head then I initially suspected."),
+                ],
+                score: 42
+            )
+        }
     }()
 }

--- a/iosApp/iosApp/Screens/Leaderboard/LeaderboardView.swift
+++ b/iosApp/iosApp/Screens/Leaderboard/LeaderboardView.swift
@@ -25,9 +25,9 @@ struct LeaderboardView<ViewModel: GameModelProtocol>: View {
                         .font(.titleSemiBold)
                     if let round = viewModel.round {
                         LazyVStack {
-                            ForEach(round.playerAnswers) { item in
+                            ForEach(round.answers) { item in
                                 LeaderboardRow(
-                                    index: round.playerAnswers.firstIndex(
+                                    index: round.answers.firstIndex(
                                         where: { $0.player.id == item.player.id }
                                     ) ?? 0,
                                     playerRound: item

--- a/iosApp/iosApp/Screens/Leaderboard/LeaderboardView.swift
+++ b/iosApp/iosApp/Screens/Leaderboard/LeaderboardView.swift
@@ -38,6 +38,7 @@ struct LeaderboardView<ViewModel: GameModelProtocol>: View {
                         .padding([.leading, .trailing], 50.0)
                     }
                 }
+                Spacer()
                 if viewModel.player?.isOwner == true {
                     PrimaryButton("Далі") {
                         viewModel.startNewRound()
@@ -45,11 +46,12 @@ struct LeaderboardView<ViewModel: GameModelProtocol>: View {
                     .padding(.bottom, 78.0)
                 }
             }
-            Spacer()
         }
-        .ignoresSafeArea()
+        .ignoresSafeArea(edges: .bottom)
     }
 }
+
+// MARK: - Previews
 
 struct LeaderboardView_Previews: PreviewProvider {
     static var previews: some View {

--- a/iosApp/iosApp/Screens/Vote/VoteView.swift
+++ b/iosApp/iosApp/Screens/Vote/VoteView.swift
@@ -21,25 +21,24 @@ struct VoteView<ViewModel: GameModelProtocol>: View {
 
     var body: some View {
         ContainerView(header: .small) {
-            VStack {
-                Text("Раунд \(viewModel.round?.number ?? 0) - Голосування")
-                    .padding(.top, .larger)
-                    .font(.titleSemiBold)
-                ZStack {
-                    VStack {
-                        SelectorView($displayedCardIndex, count: viewModel.round?.playerAnswers.count ?? 0)
-                            .padding(.top, 16.0)
-                            .padding([.leading, .trailing], 16.0)
-                        if let question = viewModel.round?.questionCard {
+            if let round = viewModel.round {
+                VStack {
+                    Text("Раунд \(round.number) - Голосування")
+                        .padding(.top, .larger)
+                        .font(.titleSemiBold)
+                    ZStack {
+                        VStack {
+                            SelectorView($displayedCardIndex, count: round.answers.count)
+                                .padding(.top, .medium)
+                                .padding([.leading, .trailing], .medium)
                             ZStack(alignment: .bottom) {
                                 VStack {
-                                    QuestionCardView(question: question.question)
+                                    QuestionCardView(question: round.questionCard.question)
                                     Spacer()
                                 }
-                                if let round = viewModel.round,
-                                   let answer = round.playerAnswers[displayedCardIndex].playerAnswers.first {
-                                    VStack {
-                                        Spacer()
+                                VStack {
+                                    Spacer()
+                                    if let answer = round.answers[displayedCardIndex].playerAnswers.first {
                                         AnswerCardView(answer: answer.text)
                                             .font(.cardSmall)
                                             .frame(width: 124, height: 168)
@@ -50,33 +49,33 @@ struct VoteView<ViewModel: GameModelProtocol>: View {
                             }
                             .padding(.top, .larger)
                             .padding(.bottom, .large)
+                            Spacer()
                         }
-                        Spacer()
-                    }
-                    HStack {
-                        Rectangle()
-                            .opacity(0.001)
-                            .onTapGesture {
-                                // TODO: Pack logic into VM
-                                if displayedCardIndex > 0 {
-                                    displayedCardIndex-=1
+                        HStack {
+                            Rectangle()
+                                .opacity(0.001)
+                                .onTapGesture {
+                                    // TODO: Pack logic into VM
+                                    if displayedCardIndex > 0 {
+                                        displayedCardIndex-=1
+                                    }
                                 }
-                            }
-                        Rectangle()
-                            .opacity(0.001)
-                            .onTapGesture {
-                                // TODO: Pack logic into VM
-                                if displayedCardIndex < (viewModel.round?.playerAnswers.count ?? 0) - 1 {
-                                    displayedCardIndex+=1
+                            Rectangle()
+                                .opacity(0.001)
+                                .onTapGesture {
+                                    // TODO: Pack logic into VM
+                                    if displayedCardIndex < (viewModel.round?.answers.count ?? 0) - 1 {
+                                        displayedCardIndex+=1
+                                    }
                                 }
-                            }
+                        }
                     }
+                    RateView($selectedRateValue) { newValue in
+                        selectedRateValue = newValue
+                        viewModel.voteForCard(at: displayedCardIndex, score: selectedRateValue)
+                    }
+                    .padding(.bottom, 40.0)
                 }
-                RateView($selectedRateValue) { newValue in
-                    selectedRateValue = newValue
-                    viewModel.voteForCard(at: displayedCardIndex, score: selectedRateValue)
-                }
-                .padding(.bottom, 40.0)
             }
         }
         .ignoresSafeArea()

--- a/iosApp/iosApp/Screens/Vote/VoteView.swift
+++ b/iosApp/iosApp/Screens/Vote/VoteView.swift
@@ -26,31 +26,30 @@ struct VoteView<ViewModel: GameModelProtocol>: View {
                     Text("Раунд \(round.number) - Голосування")
                         .padding(.top, .larger)
                         .font(.titleSemiBold)
+                    SelectorView($displayedCardIndex, count: round.answers.count)
+                        .padding(.top, .medium)
+                        .padding([.leading, .trailing], .medium)
                     ZStack {
-                        VStack {
-                            SelectorView($displayedCardIndex, count: round.answers.count)
-                                .padding(.top, .medium)
-                                .padding([.leading, .trailing], .medium)
-                            ZStack(alignment: .bottom) {
-                                VStack {
-                                    QuestionCardView(question: round.questionCard.question)
-                                    Spacer()
-                                }
-                                VStack {
-                                    Spacer()
-                                    if let answer = round.answers[displayedCardIndex].playerAnswers.first {
-                                        AnswerCardView(answer: answer.text)
-                                            .font(.cardSmall)
-                                            .frame(width: 124, height: 168)
-                                            .rotationEffect(.degrees(-8))
-                                            .offset(x: -16.0)
-                                    }
+                        ZStack(alignment: .bottom) {
+                            VStack {
+                                QuestionCardView(question: round.questionCard.question)
+                                    .frame(minWidth: 124, maxWidth: 180)
+                                Spacer()
+                            }
+                            VStack {
+                                Spacer()
+                                if let answer = round.answers[displayedCardIndex].playerAnswers.first {
+                                    AnswerCardView(answer: answer.text)
+                                        .font(.inputPrimary)
+                                        .frame(minWidth: 124, maxWidth: 180)
+                                        .rotationEffect(.degrees(-8))
+                                        .offset(x: -20)
                                 }
                             }
-                            .padding(.top, .larger)
-                            .padding(.bottom, .large)
-                            Spacer()
                         }
+                        .padding(.top, .larger)
+                        .padding(.bottom, .large)
+                        Spacer()
                         HStack {
                             Rectangle()
                                 .opacity(0.001)
@@ -78,7 +77,7 @@ struct VoteView<ViewModel: GameModelProtocol>: View {
                 }
             }
         }
-        .ignoresSafeArea()
+        .ignoresSafeArea(edges: .bottom)
     }
 }
 

--- a/iosApp/iosApp/Screens/Vote/VoteView.swift
+++ b/iosApp/iosApp/Screens/Vote/VoteView.swift
@@ -36,10 +36,11 @@ struct VoteView<ViewModel: GameModelProtocol>: View {
                                     QuestionCardView(question: question.question)
                                     Spacer()
                                 }
-                                if let answers = viewModel.round?.playerCards[displayedCardIndex].playerAnswers {
+                                if let round = viewModel.round,
+                                   let answer = round.playerCards[displayedCardIndex].playerAnswers.first {
                                     VStack {
                                         Spacer()
-                                        AnswerCardView(answer: answers[viewModel.round?.number ?? 0])
+                                        AnswerCardView(answer: answer)
                                             .font(.cardSmall)
                                             .frame(width: 124, height: 168)
                                             .rotationEffect(.degrees(-8))

--- a/iosApp/iosApp/Screens/Vote/VoteView.swift
+++ b/iosApp/iosApp/Screens/Vote/VoteView.swift
@@ -40,7 +40,7 @@ struct VoteView<ViewModel: GameModelProtocol>: View {
                                    let answer = round.playerCards[displayedCardIndex].playerAnswers.first {
                                     VStack {
                                         Spacer()
-                                        AnswerCardView(answer: answer)
+                                        AnswerCardView(answer: answer.text)
                                             .font(.cardSmall)
                                             .frame(width: 124, height: 168)
                                             .rotationEffect(.degrees(-8))
@@ -74,6 +74,7 @@ struct VoteView<ViewModel: GameModelProtocol>: View {
                 }
                 RateView($selectedRateValue) { newValue in
                     selectedRateValue = newValue
+                    viewModel.voteForCard(at: displayedCardIndex, score: selectedRateValue)
                 }
                 .padding(.bottom, 40.0)
             }
@@ -81,6 +82,8 @@ struct VoteView<ViewModel: GameModelProtocol>: View {
         .ignoresSafeArea()
     }
 }
+
+// MARK: - Previews
 
 struct VoteView_Previews: PreviewProvider {
     static var previews: some View {


### PR DESCRIPTION
This PR aims at connecting the Voting screen to the game flow. Further UI tweaks, bugfixes and logic improvements will be submitted in separate PRs.  
## In this PR
- Fixed crash on the voting screen
- Connected voting screen to navigation
- Connected voting screen to viewmodel game model  
- Fixed safe area on leaderboard view

⚠️ **This PR should be merged after:**  
- [x] https://github.com/taraspasichnyk/CAH/pull/82 is merged

related to #22 
## Recording
[<img src="https://user-images.githubusercontent.com/105276702/222790822-1fd6b04a-0307-4284-b922-acf00b0bdd74.mov" width=40%>](https://user-images.githubusercontent.com/105276702/222790822-1fd6b04a-0307-4284-b922-acf00b0bdd74.mov)


