### PR TITLE
[iOS] Fix reloading of game viewmodel

### DIFF
--- a/iosApp/iosApp/Presentation/EffectProcessors/LobbyEffectProcessor.swift
+++ b/iosApp/iosApp/Presentation/EffectProcessors/LobbyEffectProcessor.swift
@@ -43,16 +43,14 @@ final class LobbyEffectProcessor {
             let lobbyVm = navState.compactMap(\.lobbyViewModel).last ?? injector.lobbyOwnerViewModel
             navState.navigate(to: .enterName(lobbyVm))
         case let gameEffect as LobbyContractEffect.NavigationGameScreen:
-            let gameVm = injector.makeGameViewModel(
-                roomID: gameEffect.roomId,
-                playerID: gameEffect.playerID
-            )
-            subscribeToGameEffects(gameVm)
-
-            if navState.compactMap(\.gameViewModel).last != nil {
-                navState.removeLast()
+            if navState.compactMap(\.gameViewModel).last == nil {
+                let gameVm = injector.makeGameViewModel(
+                    roomID: gameEffect.roomId,
+                    playerID: gameEffect.playerID
+                )
+                subscribeToGameEffects(gameVm)
+                navState = [.game(gameVm)]
             }
-            navState.append(.game(gameVm))
         case let copyCodeEffect as LobbyContractEffect.CopyCode:
             shareController.copyToPasteboard(copyCodeEffect.code)
         case let errorEffect as LobbyContractEffect.ShowError:

--- a/iosApp/iosApp/Screens/CurrentRound/CurrentRoundView.swift
+++ b/iosApp/iosApp/Screens/CurrentRound/CurrentRoundView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct CurrentRoundView<ViewModel: GameModelProtocol>: View {
-    @ObservedObject private(set) var viewModel: ViewModel
+    @StateObject var viewModel: ViewModel
 
     @State private var hasLoaded = false
     @State private var hasShiftedTitle = false

--- a/iosApp/iosApp/Screens/Vote/VoteView.swift
+++ b/iosApp/iosApp/Screens/Vote/VoteView.swift
@@ -12,7 +12,7 @@ struct VoteView<ViewModel: GameModelProtocol>: View {
     
     // MARK: - Properties
 
-    @ObservedObject var viewModel: ViewModel
+    @StateObject var viewModel: ViewModel
 
     @State var displayedCardIndex: Int = 0
     @State var selectedRateValue: Int = 0


### PR DESCRIPTION
## In this PR:
- Changed instances of `GameViewModel` into `StateObject`s to prevent UI from redundant reloads
- Updated navigation to game, now it's replacing navigation stack entries instead of just pushing on top  

related to #17 