### PR TITLE
[iOS] Connect end-of-game navigation

### DIFF
--- a/iosApp/iosApp/Presentation/EffectProcessors/GameEffectProcessor.swift
+++ b/iosApp/iosApp/Presentation/EffectProcessors/GameEffectProcessor.swift
@@ -10,13 +10,16 @@ import SwiftUI
 import shared
 
 final class GameEffectProcessor {
+    @Binding private var navState: [NavPath]
     @Binding private var gameNavState: GameNavState
     private let alertState: AlertState
 
     init(
+        navState: Binding<[NavPath]>,
         gameNavState: Binding<GameNavState>,
         alertState: AlertState
     ) {
+        self._navState = navState
         self._gameNavState = gameNavState
         self.alertState = alertState
     }
@@ -34,6 +37,8 @@ final class GameEffectProcessor {
             gameNavState = .voting
         case is GameContractEffect.NavigationResults:
             gameNavState = .leaderBoard
+        case is GameContractEffect.NavigationMenu:
+            navState = []
         default:
             alertState.presentedAlertType = .noFeature
         }

--- a/iosApp/iosApp/Presentation/EffectProcessors/LobbyEffectProcessor.swift
+++ b/iosApp/iosApp/Presentation/EffectProcessors/LobbyEffectProcessor.swift
@@ -11,6 +11,7 @@ import shared
 
 final class LobbyEffectProcessor {
     @Binding private var navState: [NavPath]
+    @Binding private var gameNavState: GameNavState
     private let injector: Injector
     private let shareController: PasteboardControlling
     private let alertState: AlertState
@@ -18,11 +19,13 @@ final class LobbyEffectProcessor {
     init(
         injector: Injector = Injector.shared,
         navState: Binding<[NavPath]>,
+        gameNavState: Binding<GameNavState>,
         alertState: AlertState,
         shareController: PasteboardControlling
     ) {
         self.injector = injector
         self._navState = navState
+        self._gameNavState = gameNavState
         self.alertState = alertState
         self.shareController = shareController
     }
@@ -49,6 +52,7 @@ final class LobbyEffectProcessor {
                     playerID: gameEffect.playerID
                 )
                 subscribeToGameEffects(gameVm)
+                gameNavState = .yourCards
                 navState = [.game(gameVm)]
             }
         case let copyCodeEffect as LobbyContractEffect.CopyCode:

--- a/iosApp/iosApp/Screens/ContentView.swift
+++ b/iosApp/iosApp/Screens/ContentView.swift
@@ -84,6 +84,7 @@ extension ContentView {
         LobbyEffectProcessor(
             injector: injector,
             navState: $navState,
+            gameNavState: $gameNavState,
             alertState: alertState,
             shareController: shareController
         ).process(effect) { gameVm in

--- a/iosApp/iosApp/Screens/ContentView.swift
+++ b/iosApp/iosApp/Screens/ContentView.swift
@@ -97,6 +97,7 @@ extension ContentView {
 
     private func process(effect: GameContractEffect) {
         GameEffectProcessor(
+            navState: $navState,
             gameNavState: $gameNavState,
             alertState: alertState
         ).process(effect)

--- a/iosApp/iosApp/Screens/Leaderboard/LeaderboardView.swift
+++ b/iosApp/iosApp/Screens/Leaderboard/LeaderboardView.swift
@@ -40,8 +40,8 @@ struct LeaderboardView<ViewModel: GameModelProtocol>: View {
                         .padding([.leading, .trailing], 50.0)
                 }
                 Spacer()
-                PrimaryButton("Далі") {
-                    viewModel.startNewRound()
+                PrimaryButton(viewModel.round == nil ? "Завершити" : "Далі") {
+                    viewModel.onLeaderboardNextClicked()
                 }
                 .padding(.bottom, 78.0)
             }
@@ -54,6 +54,10 @@ struct LeaderboardView<ViewModel: GameModelProtocol>: View {
 
 struct LeaderboardView_Previews: PreviewProvider {
     static var previews: some View {
-        LeaderboardView(viewModel: MockGameModel(player: .mock[0]))
+        LeaderboardView(
+            viewModel: MockGameModel(
+                player: .mock[0]
+            )
+        )
     }
 }


### PR DESCRIPTION
## In this PR
- Updates to leaderboard screen to included variant for the end of the game
- Connected navigation to menu after the end of game

related to #24 

No recordings this time, cause this stage is hard to reach, but we've tested the flow several times.